### PR TITLE
Rc0.4.0

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,6 @@ comment:
   behavior: default
   flags: null
   paths: null
+ignore:
+  - "pyworkdir/tests"
+  - "pyworkdir/_version.py"

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -126,7 +126,11 @@ instance and the directory that contains the yml file, respectively::
             - 3
         my_tmpdir: {{ here/"tmpdir" }}
         my_local_tmpfile: {{ workdir/"file.tmp" }}
+    commands:
+        echo: echo Hello // print Hello to the command line
 
+The commands are shortcuts for terminal commands that can be called from python and from the command line.
+Everything after `//` is used as a documentation string for the command line interface.
 The attributes and environment variables get added to the WorkDir::
 
     import os
@@ -136,6 +140,7 @@ The attributes and environment variables get added to the WorkDir::
         for el in wd.my_list:
              print(el)
         print(os.environ["VAR_ONE"])
+
 
 Note that environment variables passed to the constructor have preference over those in a yml file.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -81,6 +81,17 @@ Calling the function from the command line looks like this::
 Writing `workdir.py` files like this makes it easy to define local functions that can be called both from inside python
 and from a terminal. For the latter, the `workdir.py` behaves similar to a Makefile.
 
+To suppress generation of the command line interface for a function, pyworkdir provides a `no_cli` decorator::
+
+    # -- workdir.py --
+
+    from pyworkdir import no_cli
+
+    @no_cli
+    def a_function_without_command_line_interface():
+        pass
+
+
 .. _Click options: https://click.palletsprojects.com/options/
 
 Changing Environment Variables

--- a/pyworkdir/__init__.py
+++ b/pyworkdir/__init__.py
@@ -13,4 +13,4 @@ del get_versions, versions
 # Add imports here
 from pyworkdir.util import WorkDirException, recursively_get_filenames, forge_method
 from pyworkdir.workdir import WorkDir
-from pyworkdir.main import show
+from pyworkdir.main import show, no_cli

--- a/pyworkdir/__init__.py
+++ b/pyworkdir/__init__.py
@@ -11,5 +11,6 @@ __git_revision__ = versions['full-revisionid']
 del get_versions, versions
 
 # Add imports here
-from pyworkdir.util import WorkDirException, recursively_get_filenames, add_function
+from pyworkdir.util import WorkDirException, recursively_get_filenames, forge_method
 from pyworkdir.workdir import WorkDir
+from pyworkdir.main import show

--- a/pyworkdir/main.py
+++ b/pyworkdir/main.py
@@ -2,6 +2,7 @@
 Command line interface
 """
 
+import pyworkdir
 from pyworkdir import WorkDir, forge_method
 
 import textwrap
@@ -31,6 +32,8 @@ def forge_command_line_interface(*args, **kwargs):
             decorate them with "@click.option(...)" to define function parameters as command line options.
             """)
     )
+    # add version option
+    main = click.version_option(version=pyworkdir.__version__, prog_name="pyworkdir")(main)
     # collect commands
     for attribute in wd.custom_attributes:
         object = getattr(wd, attribute)

--- a/pyworkdir/main.py
+++ b/pyworkdir/main.py
@@ -97,7 +97,8 @@ def bash_function(bash_command):
 @click.option("-f", "--functions", count=True, help="Print custom functions.")
 @click.option("-s", "--sources", count=True, help="Print source of custom attributes.")
 @click.option("-e", "--environment", count=True, help="Print source of custom attributes.")
-def show(workdir, variables=False, functions=False, sources=False, environment=False, out=sys.stdout):
+@click.option("-c", "--commands", count=True, help="Print source of terminal commands.")
+def show(workdir, variables=False, functions=False, sources=False, environment=False, commands=False, out=sys.stdout):
     """Print the working directory in yaml format."""
     dictionary = {"name": str(workdir)}
     if variables:
@@ -116,6 +117,8 @@ def show(workdir, variables=False, functions=False, sources=False, environment=F
         dictionary["sources"] = workdir.custom_attributes
     if environment:
         dictionary["environment"] = workdir.environment
+    if commands:
+        dictionary["commands"] = workdir.commands
     yaml.dump(dictionary, stream=out)
 
 

--- a/pyworkdir/main.py
+++ b/pyworkdir/main.py
@@ -37,7 +37,7 @@ def forge_command_line_interface(*args, **kwargs):
     # collect commands
     for attribute in wd.custom_attributes:
         object = getattr(wd, attribute)
-        if inspect.isfunction(object):
+        if inspect.isfunction(object) and not hasattr(object, "__nocli__"):
             main.command()(object)
     # default commands
     main.command()(forge_method(wd, show, replace_args={"workdir": wd}, add=False))
@@ -50,6 +50,22 @@ def entrypoint():
     """
     command_group = forge_command_line_interface()
     command_group()
+
+
+def no_cli(function):
+    """Function decorator to suppress generation of a command-line interface for this function.
+
+    Examples
+    --------
+    >>> # in workdir.py
+    >>> from pyworkdir import no_cli
+    >>>
+    >>> @no_cli
+    >>> def function_without_command_line_interace()
+    >>>     pass
+    """
+    setattr(function, "__nocli__", True)
+    return function
 
 
 # default command line interface functions

--- a/pyworkdir/main.py
+++ b/pyworkdir/main.py
@@ -2,11 +2,13 @@
 Command line interface
 """
 
-from pyworkdir import WorkDir
+from pyworkdir import WorkDir, forge_method
 
 import textwrap
 import inspect
+import sys
 
+import yaml
 import click
 
 
@@ -34,6 +36,8 @@ def forge_command_line_interface(*args, **kwargs):
         object = getattr(wd, attribute)
         if inspect.isfunction(object):
             main.command()(object)
+    # default commands
+    main.command()(forge_method(wd, show, replace_args={"workdir": wd}, add=False))
     return main
 
 
@@ -43,3 +47,33 @@ def entrypoint():
     """
     command_group = forge_command_line_interface()
     command_group()
+
+
+# default command line interface functions
+# ========================================
+
+
+@click.option("-v", "--variables", count=True, help="Print custom variables.")
+@click.option("-f", "--functions", count=True, help="Print custom functions.")
+@click.option("-s", "--sources", count=True, help="Print source of custom attributes.")
+@click.option("-e", "--environment", count=True, help="Print source of custom attributes.")
+def show(workdir, variables=False, functions=False, sources=False, environment=False, out=sys.stdout):
+    """Print the working directory in yaml format."""
+    dictionary = {"name": str(workdir)}
+    if variables:
+        variables = dict()
+        for attribute in workdir.custom_attributes:
+            if not callable(getattr(workdir, attribute)):
+                variables[attribute] = getattr(workdir, attribute)
+        dictionary["attributes"] = variables
+    if functions:
+        functions = []
+        for attribute in workdir.custom_attributes:
+            if callable(getattr(workdir, attribute)):
+                functions.append(attribute)
+        dictionary["functions"] = functions
+    if sources:
+        dictionary["sources"] = workdir.custom_attributes
+    if environment:
+        dictionary["environment"] = workdir.environment
+    yaml.dump(dictionary, stream=out)

--- a/pyworkdir/tests/test_main.py
+++ b/pyworkdir/tests/test_main.py
@@ -115,7 +115,7 @@ def test_entrypoint():
 def test_show(tmpdir):
     with WorkDir(tmpdir) as wd:
         out = StringIO()
-        show(wd, True, True, True, True, out)
+        show(wd, variables=True, environment=True, commands=True, sources=True, functions=True, out=out)
         dictionary = yaml.load(out.getvalue(), yaml.SafeLoader)
         attributes = set(dictionary["attributes"].keys())
         functions = set(dictionary["functions"])
@@ -123,10 +123,12 @@ def test_show(tmpdir):
         environment = set(dictionary["environment"])
         name = dictionary["name"]
         sources = dictionary["sources"]
+        commands = dictionary["commands"]
         assert customs == set(wd.custom_attributes.keys())
         assert environment == set(wd.environment)
         assert name == str(tmpdir)
         assert sources == wd.custom_attributes
+        assert commands == wd.commands
 
 
 def test_no_cli(tmpdir):

--- a/pyworkdir/tests/test_main.py
+++ b/pyworkdir/tests/test_main.py
@@ -2,13 +2,15 @@
 Tests for command line interface
 """
 
-from pyworkdir.main import forge_command_line_interface, entrypoint
+from pyworkdir.main import forge_command_line_interface, entrypoint, show
 from pyworkdir import WorkDir
 
 import textwrap
+from io import StringIO
 
 import pytest
 from click.testing import CliRunner
+import yaml
 
 
 def test_commandline_no_options(tmpdir):
@@ -107,3 +109,20 @@ def test_imported_terminal_commands(tmpdir):
 def test_entrypoint():
     with pytest.raises(SystemExit) as e:
         entrypoint()
+
+
+def test_show(tmpdir):
+    with WorkDir(tmpdir) as wd:
+        out = StringIO()
+        show(wd, True, True, True, True, out)
+        dictionary = yaml.load(out.getvalue(), yaml.SafeLoader)
+        attributes = set(dictionary["attributes"].keys())
+        functions = set(dictionary["functions"])
+        customs = attributes.union(functions)
+        environment = set(dictionary["environment"])
+        name = dictionary["name"]
+        sources = dictionary["sources"]
+        assert customs == set(wd.custom_attributes.keys())
+        assert environment == set(wd.environment)
+        assert name == str(tmpdir)
+        assert sources == wd.custom_attributes

--- a/pyworkdir/tests/test_main.py
+++ b/pyworkdir/tests/test_main.py
@@ -166,4 +166,4 @@ def test_terminal_command(tmpdir):
         os.system("workdir echo")
         assert os.path.isfile(tmpdir/"out.txt")
         with open(tmpdir/"out.txt", "r") as f:
-            assert f.read() == "Hello\n"
+            assert f.read().strip() == "Hello"

--- a/pyworkdir/tests/test_main.py
+++ b/pyworkdir/tests/test_main.py
@@ -126,3 +126,22 @@ def test_show(tmpdir):
         assert environment == set(wd.environment)
         assert name == str(tmpdir)
         assert sources == wd.custom_attributes
+
+
+def test_no_cli(tmpdir):
+    content = textwrap.dedent(
+        """
+        from click import option
+        from pyworkdir import no_cli
+        
+        @no_cli
+        @option("-s")
+        def imported_function(s):
+            print(s)
+        """)
+    with open(tmpdir / "workdir.py", 'w') as f:
+        f.write(content)
+    runner = CliRunner(env={"PWD": str(tmpdir)})
+    main = forge_command_line_interface(directory=tmpdir)
+    result = runner.invoke(main, "--help")
+    assert not "imported-function" in result.output

--- a/pyworkdir/tests/test_main.py
+++ b/pyworkdir/tests/test_main.py
@@ -113,6 +113,27 @@ def test_entrypoint():
 
 
 def test_show(tmpdir):
+    content = textwrap.dedent(
+        """
+        a = 1
+        def b(s):
+            print(s)
+        """
+    )
+    with open(tmpdir / "workdir.py", 'w') as f:
+        f.write(content)
+    content = textwrap.dedent(
+        """
+        environment:
+            A: 1
+        commands:
+            echo: echo // echo
+        attributes: 
+            c: a
+        """
+    )
+    with open(tmpdir / "workdir.yml", 'w') as f:
+        f.write(content)
     with WorkDir(tmpdir) as wd:
         out = StringIO()
         show(wd, variables=True, environment=True, commands=True, sources=True, functions=True, out=out)

--- a/pyworkdir/tests/test_util.py
+++ b/pyworkdir/tests/test_util.py
@@ -4,7 +4,7 @@ Tests for utilities.
 
 import sys
 import textwrap
-from pyworkdir.util import add_function, import_from_file
+from pyworkdir.util import forge_method, import_from_file
 
 
 def test_add_method_replace_args():
@@ -17,7 +17,7 @@ def test_add_method_replace_args():
         return b + instance.internal_value
 
     instance = A(2)
-    add_function(instance, function_to_be_method, replace_args={"instance": instance})
+    forge_method(instance, function_to_be_method, replace_args={"instance": instance})
     assert hasattr(instance, "function_to_be_method")
     assert instance.function_to_be_method(3) == 5
 
@@ -33,7 +33,7 @@ def test_specify_name():
         return 1
 
     instance = A()
-    add_function(instance, f, name="jambalaya")
+    forge_method(instance, f, name="jambalaya")
     assert hasattr(instance, "jambalaya")
     assert instance.jambalaya() == 1
 
@@ -47,7 +47,7 @@ def test_add_staticmethod():
         return b
     instance = A()
 
-    add_function(instance, function_to_be_method)
+    forge_method(instance, function_to_be_method)
     assert function_to_be_method(3) == 3
 
 
@@ -61,7 +61,7 @@ def test_add_method_click_options():
         return b + instance.internal_value
 
     instance = A(2)
-    add_function(instance, function_to_be_method, replace_args={"instance": instance, "o_ther": 2})
+    forge_method(instance, function_to_be_method, replace_args={"instance": instance, "o_ther": 2})
     assert hasattr(instance, "function_to_be_method")
     assert hasattr(instance.function_to_be_method, "__click_params__")
     options = instance.function_to_be_method.__click_params__

--- a/pyworkdir/tests/test_workdir.py
+++ b/pyworkdir/tests/test_workdir.py
@@ -447,3 +447,23 @@ def test_redefine_function_arguments_locally(tmpdir):
     wd = WorkDir(tmpdir)
     assert hasattr(wd, "dirname")
     assert list(wd.custom_attributes.keys()) == ["dirname"]
+
+
+def test_terminal_command(tmpdir):
+    with WorkDir(tmpdir) as wd:
+        assert len(wd.commands) == 0
+    content = textwrap.dedent("""
+        commands:
+             echo: echo Hello > {{ here/"out.txt" }} // print something
+        """)
+    with open(tmpdir / "workdir.yml", 'w') as f:
+        f.write(content)
+    with WorkDir(tmpdir) as wd:
+        assert len(wd.commands) == 1
+        assert wd.commands["echo"] == f"echo Hello > {str(tmpdir/'out.txt')} // print something"
+
+    with WorkDir(tmpdir):
+        wd.echo()
+        assert os.path.isfile(tmpdir/"out.txt")
+        with open(tmpdir/"out.txt", "r") as f:
+            assert f.read() == "Hello\n"

--- a/pyworkdir/tests/test_workdir.py
+++ b/pyworkdir/tests/test_workdir.py
@@ -466,4 +466,4 @@ def test_terminal_command(tmpdir):
         wd.echo()
         assert os.path.isfile(tmpdir/"out.txt")
         with open(tmpdir/"out.txt", "r") as f:
-            assert f.read() == "Hello\n"
+            assert f.read().strip() == "Hello"

--- a/pyworkdir/util.py
+++ b/pyworkdir/util.py
@@ -55,9 +55,9 @@ def recursively_get_filenames(path, filenames, recursion_depth, current_recursio
         return parentfiles + this_dir_files
 
 
-def add_function(instance, func, replace_args=dict(), name=None):
+def forge_method(instance, func, replace_args=dict(), name=None, add=True):
     """
-    Add a function to an object.
+    Forge a method and add it to an instance.
 
     Parameters
     ----------
@@ -69,6 +69,8 @@ def add_function(instance, func, replace_args=dict(), name=None):
         Any arguments that are replaced by default values in the spirit of functools.partial
     name : str, Optional, default=None
         The function's name; if None, infer from function.__name__
+    add : bool, Optional, default=True
+        If False, do not add the function but return it instead.
 
     Notes
     -----
@@ -105,7 +107,10 @@ def add_function(instance, func, replace_args=dict(), name=None):
                 hidden=True
             )(method)
 
-    setattr(instance, name, method)
+    if add:
+        setattr(instance, name, method)
+    else:
+        return method
 
 
 def import_from_file(filename):

--- a/pyworkdir/workdir.py
+++ b/pyworkdir/workdir.py
@@ -179,8 +179,6 @@ class WorkDir(object):
             loglevel_console=logging.INFO,
             loglevel_file=logging.DEBUG
     ):
-        """
-        """
         self.path = pathlib.Path(os.path.realpath(directory))
         self.scope_path = copy(self.path)
         self.custom_attributes = {}

--- a/pyworkdir/workdir.py
+++ b/pyworkdir/workdir.py
@@ -9,7 +9,7 @@ import logging
 import traceback
 from copy import copy
 from pyworkdir.util import (
-    WorkDirException, add_function, recursively_get_filenames, import_from_file)
+    WorkDirException, forge_method, recursively_get_filenames, import_from_file)
 
 import yaml
 import jinja2
@@ -240,6 +240,17 @@ class WorkDir(object):
     def __len__(self):
         return len(os.listdir(str(self.path)))
 
+    #def __call__(self, *command, **kwargs):
+    #    self.terminal_command(command, **kwargs)
+
+    #def terminal_command(self, command, decoding="latin-1"):
+    #    if len(command) == 1 and isinstance(command[0], str):
+    #        command = [shlex.split(command)]
+    #    assert len(command) > 0
+    #    p = subprocess.Popen(command, stdout=subprocess.PIPE)
+    #    out, err = p.communicate()
+    #    return out.decode(decoding)[:-1]
+
     def files(self, abs=False):
         """
         Iterator over files in this work dir.
@@ -320,7 +331,7 @@ class WorkDir(object):
                 continue
             self.custom_attributes[name] = str(pyfile)
             if inspect.isfunction(object):
-                add_function(
+                forge_method(
                     self,
                     object,
                     replace_args={"workdir": self, "here": pathlib.Path(os.path.dirname(pyfile))},
@@ -337,6 +348,7 @@ class WorkDir(object):
             dictionary = yaml.load(jinja2.Template(f.read()).render(workdir=self, here=yml_file.parent), Loader=yaml.SafeLoader)
             if "attributes" in dictionary:
                 for attribute in dictionary["attributes"]:
+                    self.custom_attributes[attribute] = str(yml_file)
                     setattr(self, attribute, dictionary["attributes"][attribute])
             if "environment" in dictionary:
                 self.environment.update(dictionary["environment"])
@@ -360,3 +372,4 @@ class WorkDir(object):
         console_formatter = logging.Formatter('%(message)s')
         console_handler.setFormatter(console_formatter)
         self.logger.addHandler(console_handler)
+

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Self-descriptive entries which should always be present
     name='pyworkdir',
     author='Andreas Krämer',
-    entry_points={'console_scripts': ['workdir=pyworkdir.main:entrypoint']},
+    entry_points={'console_scripts': ['wd=pyworkdir.main:entrypoint','workdir=pyworkdir.main:entrypoint']},
     author_email='kraemer.research@gmail.com',
     description=short_description[0],
     long_description=long_description,


### PR DESCRIPTION
- added a 'commands' section to workdir.yml to support terminal shortcuts.
- added version option
- added a no_cli decorator to suppress generation of a command line interface
- added 'workdir show' command 
